### PR TITLE
ETL example of using Glue and Athena to transform relational model to graph model

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ This is an [example](gremlin/collaborative-filtering/README.md) of using Gremlin
 #### Visualize data in Amazon Neptune using VIS.js library
 This [GitHub lab](gremlin/visjs-neptune) will take you through hands-on excercise of visualizing graph data in Amazon Neptune using VIS.js library. Amazon Neptune is a fast, reliable, fully-managed graph database service available from AWS. With Amazon Neptune you can use open source and popular graph query languages such as Apache TinkerPop Gremlin for property graph databases or SPARQL for W3C RDF model graph databases.
 
+### ETL Process for Transforming and Loading Data Into Amazon Neptune
+The following [lab](gremlin/etl-from-relational-model) uses the open [IMDB dataset](https://www.imdb.com/interfaces/). This is a small subset of the full IMDB.com application. With this dataset, we want to develop an application that allows for us to find whether or not an actor or actress is no more than [six degrees separated from the actor Kevin Bacon](https://en.wikipedia.org/wiki/Six_Degrees_of_Kevin_Bacon).  In this example, AWS Glue and Amazon Athena are used to discover and transform the relational model used by IMDB into a graph model that can be loaded into Amazon Neptune.  This pattern can be used to transform other relational models into graph models for similar purposes.
+
 ### SPARQL
 **Coming soon!**
 


### PR DESCRIPTION
Request to add the following lab/example to the neptune-samples repo.  

This is a single README.md file that walks a customer through how to leverage AWS Glue and Amazon Athena to crawl a dataset that is relational in nature.  The discovered DDL from Glue can then be used to transform this data using SQL queries in Amazon Athena to build CSV files in the format compliant with the Neptune bulk loader.  This uses a fun example from the IMDB (Internet Movie Database) open dataset for someone to quickly build an application to answer queries associated with the Six Degrees of Kevin Bacon.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
