### PR TITLE
replaces all versions of nodejs to 10.x

### DIFF
--- a/gremlin/visjs-neptune/README.md
+++ b/gremlin/visjs-neptune/README.md
@@ -114,7 +114,7 @@ NOTE: Use `subnet-ids` from the VPC in which Amazon Neptune cluster is provision
 ```
 aws lambda create-function --function-name <lambda-function-name> \
 --role "arn:aws:iam::<aws-account-number>:role/service-role/lambda-vpc-access-role" \
---runtime nodejs8.10 --handler indexLambda.handler \
+--runtime nodejs10.x --handler indexLambda.handler \
 --description "Lambda function to make gremlin calls to Amazon Neptune" \
 --timeout 120 --memory-size 256 --publish \
 --vpc-config SubnetIds=<subnet-ids>,SecurityGroupIds=<sec-group-id> \


### PR DESCRIPTION
Because nodejs8.10 is no longer a supported runtime

Resolves #32 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
