### PR TITLE
fix: remove deprecated runtime from template

### DIFF
--- a/neptune-sagemaker/cloudformation-templates/common/add-iam-role-to-neptune.json
+++ b/neptune-sagemaker/cloudformation-templates/common/add-iam-role-to-neptune.json
@@ -6,9 +6,7 @@
 			"Description": "The Lambda runtime to use",
 			"Type": "String",
 			"AllowedValues": [
-				"nodejs4.3",
-				"python3.7",
-				"java8"
+				"python3.7"
 			],
 			"Default": "python3.7"
 		},


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This template was allowing nodejs4.3 as a potential runtime. However,
nodejs4.3 has been deprecated since March 2020. Since the Lambda
function code is in Python, I removed all AllowedValues except for
python3.7.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
