### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/gremlin/visjs-neptune/README.md
+++ b/gremlin/visjs-neptune/README.md
@@ -114,7 +114,7 @@ NOTE: Use `subnet-ids` from the VPC in which Amazon Neptune cluster is provision
 ```
 aws lambda create-function --function-name <lambda-function-name> \
 --role "arn:aws:iam::<aws-account-number>:role/service-role/lambda-vpc-access-role" \
---runtime nodejs10.x --handler indexLambda.handler \
+--runtime nodejs14.x --handler indexLambda.handler \
 --description "Lambda function to make gremlin calls to Amazon Neptune" \
 --timeout 120 --memory-size 256 --publish \
 --vpc-config SubnetIds=<subnet-ids>,SecurityGroupIds=<sec-group-id> \


### PR DESCRIPTION
CloudFormation templates in amazon-neptune-samples have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.