### PR TITLE
Move Neptune Workbench CloudFormation template out of neptune-sagemaker

### DIFF
--- a/neptune-workbench-cloudformation/LICENSE
+++ b/neptune-workbench-cloudformation/LICENSE
@@ -1,0 +1,14 @@
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/neptune-workbench-cloudformation/README.md
+++ b/neptune-workbench-cloudformation/README.md
@@ -1,0 +1,58 @@
+### What it does
+This AWS CloudFormation template deploys Amazon Neptune workbench notebooks as resources, and includes the base 'Getting Started' notebooks. The workbench lets you work with your Amazon Neptune cluster using Jupyter notebooks hosted by Amazon SageMaker. You are billed for workbench resources through Amazon SageMaker, separately from your Neptune billing.
+
+
+### Parameter details
+#### Minimum permissions for the SageMakerNotebookRole
+This is the ARN for the AWS IAM role that the notebook instance will assume. Make sure that this role has at least the following minimum permissions within its service role policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::aws-neptune-notebook",
+        "arn:aws:s3:::aws-neptune-notebook/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "neptune-db:connect",
+      "Resource": [
+        "your-cluster-arn/*"
+      ]
+    }
+  ]
+}
+```
+
+The role should also establish the following trust relationship:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "sagemaker.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```
+
+#### How to populate the 'Cluster' value within the AWS Console for Amazon Neptune Notebooks
+Add the following tags manually to the notebook instance.
+
+| Key | Value |
+| ------------- |-------------|
+| **aws-neptune-cluster-id** | Amazon Neptune database cluster ID (found under *DB cluster id* under *Configuration* of the selected cluster in the AWS console) |
+| **aws-neptune-resource-id** | Amazon Neptune cluster resource ID (found under *Resource id* under *Configuration* of the selected cluster in the AWS console) |

--- a/neptune-workbench-cloudformation/neptune-workbench-stack.yaml
+++ b/neptune-workbench-cloudformation/neptune-workbench-stack.yaml
@@ -1,0 +1,130 @@
+AWSTemplateFormatVersion: '2010-09-09'
+
+Description: A template to deploy Neptune Notebooks using CloudFormation resources.
+
+Parameters:
+  NotebookInstanceType:
+    Description: The notebook instance type.
+    Type: String
+    Default: ml.t2.medium
+    AllowedValues:
+    - ml.t2.medium
+    - ml.t2.large
+    - ml.t2.xlarge
+    - ml.t2.2xlarge
+    - ml.t3.2xlarge
+    - ml.t3.large
+    - ml.t3.medium
+    - ml.t3.xlarge
+    - ml.m4.xlarge
+    - ml.m4.2xlarge
+    - ml.m4.4xlarge
+    - ml.m4.10xlarge
+    - ml.m4.16xlarge
+    - ml.m5.12xlarge
+    - ml.m5.24xlarge
+    - ml.m5.2xlarge
+    - ml.m5.4xlarge
+    - ml.m5.xlarge
+    - ml.p2.16xlarge
+    - ml.p2.8xlarge
+    - ml.p2.xlarge
+    - ml.p3.16xlarge
+    - ml.p3.2xlarge
+    - ml.p3.8xlarge
+    - ml.c4.2xlarge
+    - ml.c4.4xlarge
+    - ml.c4.8xlarge
+    - ml.c4.xlarge
+    - ml.c5.18xlarge
+    - ml.c5.2xlarge
+    - ml.c5.4xlarge
+    - ml.c5.9xlarge
+    - ml.c5.xlarge
+    - ml.c5d.18xlarge
+    - ml.c5d.2xlarge
+    - ml.c5d.4xlarge
+    - ml.c5d.9xlarge
+    - ml.c5d.xlarge
+    ConstraintDescription: Must be a valid SageMaker instance type.
+
+  NeptuneClusterEndpoint:
+    Description: The cluster endpoint of an existing Neptune cluster.
+    Type: String
+
+  NeptuneClusterPort:
+    Description: 'OPTIONAL: The Port of an existing Neptune cluster (default 8182).'
+    Type: String
+    Default: '8182'
+
+  NeptuneClusterSecurityGroups:
+    Description: The VPC security group IDs. The security groups must be for the same VPC as specified in the subnet.
+    Type: List<AWS::EC2::SecurityGroup::Id>
+
+  NeptuneClusterSubnetId:
+    Description: The ID of the subnet in a VPC to which you would like to have a connectivity from your ML compute instance.
+    Type: AWS::EC2::Subnet::Id
+
+  SageMakerNotebookRole:
+    Description: The ARN for the IAM role that the notebook instance will assume.
+    Type: String
+    AllowedPattern: ^arn:aws[a-z\-]*:iam::\d{12}:role/?[a-zA-Z_0-9+=,.@\-_/]+$
+
+  SageMakerNotebookName:
+    Description: The name of the Neptune notebook.
+    Type: String
+
+Resources:
+  NeptuneNotebookInstance:
+    Type: AWS::SageMaker::NotebookInstance
+    Properties:
+      NotebookInstanceName: !Join
+                          - ''
+                          - - 'aws-neptune-'
+                            - !Ref SageMakerNotebookName
+      InstanceType:
+        Ref: NotebookInstanceType
+      SubnetId:
+        Ref: NeptuneClusterSubnetId
+      SecurityGroupIds:
+        Ref: NeptuneClusterSecurityGroups
+      RoleArn:
+        Ref: SageMakerNotebookRole
+      LifecycleConfigName:
+        Fn::GetAtt:
+        - NeptuneNotebookInstanceLifecycleConfig
+        - NotebookInstanceLifecycleConfigName
+
+  NeptuneNotebookInstanceLifecycleConfig:
+    Type: AWS::SageMaker::NotebookInstanceLifecycleConfig
+    Properties:
+      OnStart:
+      - Content:
+          Fn::Base64:
+            Fn::Join:
+            - ''
+            - - "#!/bin/bash\n"
+              - sudo -u ec2-user -i << 'EOF'
+              - "\n"
+              - echo 'export GRAPH_NOTEBOOK_AUTH_MODE=
+              - "DEFAULT' >> ~/.bashrc\n"
+              - echo 'export GRAPH_NOTEBOOK_HOST=
+              - !Ref NeptuneClusterEndpoint
+              - "' >> ~/.bashrc\n"
+              - echo 'export GRAPH_NOTEBOOK_PORT=
+              - !Ref NeptuneClusterPort
+              - "' >> ~/.bashrc\n"
+              - echo 'export NEPTUNE_LOAD_FROM_S3_ROLE_ARN=
+              - "' >> ~/.bashrc\n"
+              - echo 'export AWS_REGION=
+              - !Ref AWS::Region
+              - "' >> ~/.bashrc\n"
+              - aws s3 cp s3://aws-neptune-notebook/graph_notebook.tar.gz /tmp/graph_notebook.tar.gz
+              - "\n"
+              - rm -rf /tmp/graph_notebook
+              - "\n"
+              - tar -zxvf /tmp/graph_notebook.tar.gz -C /tmp
+              - "\n"
+              - /tmp/graph_notebook/install.sh
+              - "\n"
+              - EOF


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Pulled the CloudFormation template for the Neptune Workbench out of the now-deprecated neptune-sagemaker directory, into the root folder. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
