### PR TITLE
feat(cdk): Add cdk python example for deploying an Amazon Neptune clu…

### DIFF
--- a/neptune-sagemaker/cdk/python/neptune-notebook/.gitignore
+++ b/neptune-sagemaker/cdk/python/neptune-notebook/.gitignore
@@ -1,0 +1,11 @@
+*.swp
+package-lock.json
+__pycache__
+.pytest_cache
+.venv
+*.egg-info
+
+# CDK asset staging directory
+.cdk.staging
+cdk.out
+source.bat

--- a/neptune-sagemaker/cdk/python/neptune-notebook/README.md
+++ b/neptune-sagemaker/cdk/python/neptune-notebook/README.md
@@ -1,0 +1,66 @@
+
+# Deploy an Amazon Neptune cluster with Amazon SageMaker Notebook using CDK
+
+Amazon Neptune now offers a workbench, an in-console experience to query your graph. The workbench lets you quickly and easily query your Neptune databases with Jupyter notebooks – a fully managed, interactive development environment with live code and narrative text. You can also invoke the bulk loader, run query plans and profile queries using the notebook. The notebooks also contain samples to help you get started with Neptune quickly. 
+
+This CDK project automates the process of creating the Neptune cluster with a SageMaker Notebook configured to connect to the Neptune cluster.
+
+The `cdk.json` file tells the CDK Toolkit how to execute your app.
+
+This project is set up like a standard Python project.  The initialization
+process also creates a virtualenv within this project, stored under the `.venv`
+directory.  To create the virtualenv it assumes that there is a `python3`
+(or `python` for Windows) executable in your path with access to the `venv`
+package. If for any reason the automatic creation of the virtualenv fails,
+you can create the virtualenv manually.
+
+To manually create a virtualenv on MacOS and Linux:
+
+```
+$ python -m venv .venv
+```
+
+After the init process completes and the virtualenv is created, you can use the following
+step to activate your virtualenv.
+
+```
+$ source .venv/bin/activate
+```
+
+If you are a Windows platform, you would activate the virtualenv like this:
+
+```
+% .venv\Scripts\activate.bat
+```
+
+Once the virtualenv is activated, you can install the required dependencies.
+
+```
+$ pip install -r requirements.txt
+```
+
+At this point you can now synthesize the CloudFormation template for this code.
+
+```
+$ cdk synth
+```
+
+Deploy the entire stack to your AWS account.
+
+```
+$ cdk deploy
+```
+
+To add additional dependencies, for example other CDK libraries, just add
+them to your `requirements.txt` file and rerun the `pip install -r requirements.txt`
+command.
+
+## Useful commands
+
+ * `cdk ls`          list all stacks in the app
+ * `cdk synth`       emits the synthesized CloudFormation template
+ * `cdk deploy`      deploy this stack to your default AWS account/region
+ * `cdk diff`        compare deployed stack with current state
+ * `cdk docs`        open CDK documentation
+
+Enjoy!

--- a/neptune-sagemaker/cdk/python/neptune-notebook/app.py
+++ b/neptune-sagemaker/cdk/python/neptune-notebook/app.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+import os
+
+import aws_cdk as cdk
+
+from neptune_notebook.neptune_notebook_stack import NeptuneNotebookStack
+
+
+app = cdk.App()
+NeptuneNotebookStack(app, "NeptuneNotebookStack",
+    # If you don't specify 'env', this stack will be environment-agnostic.
+    # Account/Region-dependent features and context lookups will not work,
+    # but a single synthesized template can be deployed anywhere.
+
+    # Uncomment the next line to specialize this stack for the AWS Account
+    # and Region that are implied by the current CLI configuration.
+
+    #env=cdk.Environment(account=os.getenv('CDK_DEFAULT_ACCOUNT'), region=os.getenv('CDK_DEFAULT_REGION')),
+
+    # Uncomment the next line if you know exactly what Account and Region you
+    # want to deploy the stack to. */
+
+    #env=cdk.Environment(account='123456789012', region='us-east-1'),
+
+    # For more information, see https://docs.aws.amazon.com/cdk/latest/guide/environments.html
+    )
+
+app.synth()

--- a/neptune-sagemaker/cdk/python/neptune-notebook/cdk.json
+++ b/neptune-sagemaker/cdk/python/neptune-notebook/cdk.json
@@ -1,0 +1,30 @@
+{
+  "app": "python app.py",
+  "watch": {
+    "include": [
+      "**"
+    ],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "requirements*.txt",
+      "source.bat",
+      "**/__init__.py",
+      "python/__pycache__",
+      "tests"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
+    "@aws-cdk/core:stackRelativeExports": true,
+    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
+    "@aws-cdk/aws-lambda:recognizeVersionProps": true,
+    "@aws-cdk/aws-cloudfront:defaultSecurityPolicyTLSv1.2_2021": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/aws-ec2:uniqueImdsv2TemplateName": true,
+    "@aws-cdk/core:target-partitions": [
+      "aws",
+      "aws-cn"
+    ]
+  }
+}

--- a/neptune-sagemaker/cdk/python/neptune-notebook/neptune_notebook/neptune_notebook_stack.py
+++ b/neptune-sagemaker/cdk/python/neptune-notebook/neptune_notebook/neptune_notebook_stack.py
@@ -1,0 +1,128 @@
+from aws_cdk import (
+    Stack,
+    Fn,
+    Tags,
+    Aws,
+    aws_ec2 as ec2, 
+    aws_iam as iam, 
+    aws_sagemaker as sagemaker,
+    RemovalPolicy
+)
+import aws_cdk.aws_neptune_alpha as neptune
+from constructs import Construct
+
+class NeptuneNotebookStack(Stack):
+
+    def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
+        super().__init__(scope, construct_id, **kwargs)
+
+        # Create a VPC
+        neptune_vpc = ec2.Vpc(self, "Neptune-CDK-VPC")
+
+        # Cluster Parameters
+        cluster_params = neptune.ClusterParameterGroup(self, "Neptune-CDK-ClusterParams",
+            description="Neptune CDK Cluster parameter group",
+            parameters={
+                "neptune_enable_audit_log": "1"
+            }
+        )
+
+        db_params = neptune.ParameterGroup(self, "Neptune-CDK-DbParams",
+            description="Neptune CDK Db parameter group",
+            parameters={
+                "neptune_query_timeout": "120000"
+            }
+        )
+
+        # Create a Neptune Cluster
+        neptune_cluster = neptune.DatabaseCluster(self, "Neptune-CDK-Cluster",
+            vpc=neptune_vpc,
+            instance_type=neptune.InstanceType.T3_MEDIUM,
+            cluster_parameter_group=cluster_params,
+            parameter_group=db_params,
+            port=8182,
+            removal_policy=RemovalPolicy.DESTROY
+        )        
+
+        # Allow access within the security group
+        neptune_cluster.connections.allow_default_port_internally()
+
+        neptune_cluster.node.add_dependency(neptune_vpc)
+
+        # Create a Notebook connecting to the Neptune Cluster
+        self.create_notebook(neptune_vpc, neptune_cluster)
+
+    def create_notebook(self, neptune_vpc: ec2.Vpc, neptune_cluster: neptune.DatabaseCluster):
+        """
+        Create a Notebook Instance attached to the Neptune Cluster
+        """
+        # Create an IAM policy for the Notebook
+        notebook_role_policy_doc = iam.PolicyDocument()
+        notebook_role_policy_doc.add_statements(iam.PolicyStatement(**{
+            "effect": iam.Effect.ALLOW,
+            "resources": ["arn:aws:s3:::aws-neptune-notebook",
+                "arn:aws:s3:::aws-neptune-notebook/*"],
+            "actions": ["s3:GetObject",
+                "s3:ListBucket"]
+            })
+        )
+        
+        # Allow Notebook to access Neptune Cluster
+        notebook_role_policy_doc.add_statements(iam.PolicyStatement(**{
+        "effect": iam.Effect.ALLOW,
+        "resources": ["arn:aws:neptune-db:{region}:{account}:{cluster_id}/*".format(
+            region=Aws.REGION, account=Aws.ACCOUNT_ID, cluster_id=neptune_cluster.cluster_resource_identifier)],
+        "actions": ["neptune-db:connect"]
+            })
+        )
+
+        # Create a role and add the policy to it
+        notebook_role = iam.Role(self, 'Neptune-CDK-Notebook-Role',
+            role_name='AWSNeptuneNotebookRole-CDK',
+            assumed_by=iam.ServicePrincipal('sagemaker.amazonaws.com'),
+            inline_policies={
+                'AWSNeptuneNotebook-CDK': notebook_role_policy_doc
+            }
+        )
+
+        notebook_lifecycle_script = f'''#!/bin/bash
+sudo -u ec2-user -i <<'EOF'
+echo "export GRAPH_NOTEBOOK_AUTH_MODE=DEFAULT" >> ~/.bashrc
+echo "export GRAPH_NOTEBOOK_HOST={neptune_cluster.cluster_endpoint.hostname}" >> ~/.bashrc
+echo "export GRAPH_NOTEBOOK_PORT=8182" >> ~/.bashrc
+echo "export NEPTUNE_LOAD_FROM_S3_ROLE_ARN=" >> ~/.bashrc
+echo "export AWS_REGION={Aws.REGION}" >> ~/.bashrc
+aws s3 cp s3://aws-neptune-notebook/graph_notebook.tar.gz /tmp/graph_notebook.tar.gz
+rm -rf /tmp/graph_notebook
+tar -zxvf /tmp/graph_notebook.tar.gz -C /tmp
+/tmp/graph_notebook/install.sh
+EOF
+'''
+        notebook_lifecycle_config = sagemaker.CfnNotebookInstanceLifecycleConfig(self, 'NpetuneWorkbenchLifeCycleConfig',
+            notebook_instance_lifecycle_config_name='aws-neptune-cdk-example-LC',
+            on_start=[sagemaker.CfnNotebookInstanceLifecycleConfig.NotebookInstanceLifecycleHookProperty(
+            content=Fn.base64(notebook_lifecycle_script)
+            )]
+        )
+
+        neptune_security_group = neptune_cluster.connections.security_groups[0]
+        neptune_security_group_id = neptune_security_group.security_group_id
+        neptune_subnet = neptune_vpc.select_subnets(subnet_type=ec2.SubnetType.PRIVATE_WITH_NAT).subnets[0]
+        neptune_subnet_id = neptune_subnet.subnet_id
+
+        notebook = sagemaker.CfnNotebookInstance(self, 'CDKNeptuneWorkbench',
+            instance_type='ml.t3.medium',
+            role_arn=notebook_role.role_arn,
+            lifecycle_config_name=notebook_lifecycle_config.notebook_instance_lifecycle_config_name,
+            notebook_instance_name='cdk-neptune-workbench',
+            root_access='Disabled',
+            security_group_ids=[neptune_security_group_id],
+            subnet_id=neptune_subnet_id,
+            direct_internet_access='Enabled',
+        )
+        Tags.of(notebook).add('aws-neptune-cluster-id', neptune_cluster.cluster_identifier)
+        Tags.of(notebook).add('aws-neptune-resource-id', neptune_cluster.cluster_resource_identifier)
+
+        notebook.node.add_dependency(neptune_cluster)
+        notebook.node.add_dependency(neptune_security_group)
+        notebook.node.add_dependency(neptune_subnet)        

--- a/neptune-sagemaker/cdk/python/neptune-notebook/requirements.txt
+++ b/neptune-sagemaker/cdk/python/neptune-notebook/requirements.txt
@@ -1,0 +1,3 @@
+aws-cdk-lib==2.10.0
+constructs>=10.0.0,<11.0.0
+aws-cdk.aws-neptune-alpha==2.10.0a0


### PR DESCRIPTION
### Deploy an Amazon Neptune cluster with Amazon SageMaker Notebook using CDK

This CDK project implements a CDK stack written in python to build and deploy a Neptune cluster with SageMaker Notebook configured to connect to the cluster, to run queries against the graph.

Issue #90

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
