### PR TITLE
Update notebook name so it is shown on console

### DIFF
--- a/neptune-sagemaker/cdk/python/neptune-notebook/neptune_notebook/neptune_notebook_stack.py
+++ b/neptune-sagemaker/cdk/python/neptune-notebook/neptune_notebook/neptune_notebook_stack.py
@@ -114,7 +114,7 @@ EOF
             instance_type='ml.t3.medium',
             role_arn=notebook_role.role_arn,
             lifecycle_config_name=notebook_lifecycle_config.notebook_instance_lifecycle_config_name,
-            notebook_instance_name='cdk-neptune-workbench',
+            notebook_instance_name='aws-neptune-workbench',
             root_access='Disabled',
             security_group_ids=[neptune_security_group_id],
             subnet_id=neptune_subnet_id,


### PR DESCRIPTION
In order for a Notebook Instance to be shown on the Notebooks page of the Neptune service, the instance name *must* be prefixed with `aws-neptune-`.

*Issue #, if available:*

N/A

*Description of changes:*

Updates the notebook name


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
