### PR TITLE
Make config auth mode configurable in workbench template

### DIFF
--- a/neptune-workbench-cloudformation/neptune-workbench-stack.yaml
+++ b/neptune-workbench-cloudformation/neptune-workbench-stack.yaml
@@ -57,6 +57,14 @@ Parameters:
     Type: String
     Default: '8182'
 
+  NeptuneClusterAuthMode:
+    Description: 'The IAM authentication mode on the specified Neptune cluster.'
+    Type: String
+    Default: DEFAULT
+    AllowedValues:
+      - DEFAULT
+      - IAM
+
   NeptuneClusterSecurityGroups:
     Description: The VPC security group IDs. The security groups must be for the same VPC as specified in the subnet.
     Type: List<AWS::EC2::SecurityGroup::Id>
@@ -107,7 +115,8 @@ Resources:
               - sudo -u ec2-user -i << 'EOF'
               - "\n"
               - echo 'export GRAPH_NOTEBOOK_AUTH_MODE=
-              - "DEFAULT' >> ~/.bashrc\n"
+              - !Ref NeptuneClusterAuthMode
+              - "' >> ~/.bashrc\n"
               - echo 'export GRAPH_NOTEBOOK_HOST=
               - !Ref NeptuneClusterEndpoint
               - "' >> ~/.bashrc\n"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- Adds `NeptuneClusterAuthMode` option to the Neptune Workbench CFN template. Allows user to specify the IAM auth mode for the notebook config, this was previously always set to non-IAM by default.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
