### PR TITLE
Upgrade deprecated runtime python3.7

### DIFF
--- a/gremlin/glue-neptune/cloudformation-templates/glue-neptune-stack.json
+++ b/gremlin/glue-neptune/cloudformation-templates/glue-neptune-stack.json
@@ -442,8 +442,8 @@
                 {
                   "Ref": "AWS::Region"
                 },
-                "/neptune-sagemaker/bin/neptune-python-utils-v2/neptune_python_utils.zip /home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.7/site-packages/\n",
-                "unzip -n /home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.7/site-packages/neptune_python_utils.zip -d /home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.7/site-packages/\n",
+                "/neptune-sagemaker/bin/neptune-python-utils-v2/neptune_python_utils.zip /home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.10/site-packages/\n",
+                "unzip -n /home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.10/site-packages/neptune_python_utils.zip -d /home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.10/site-packages/\n",
                 "echo 'export NEPTUNE_CLUSTER_ENDPOINT=",
                 {
                   "Fn::GetAtt": [

--- a/gremlin/neptune-gremlin-client-demo/cloudformation-templates/neptune-gremlin-client-demo.json
+++ b/gremlin/neptune-gremlin-client-demo/cloudformation-templates/neptune-gremlin-client-demo.json
@@ -304,8 +304,8 @@
                 {
                   "Ref": "AWS::Region"
                 },
-                "/neptune-sagemaker/bin/neptune-python-utils-v2/neptune_python_utils.zip /home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.7/site-packages/\n",
-                "unzip -n /home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.7/site-packages/neptune_python_utils.zip -d /home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.7/site-packages/\n",
+                "/neptune-sagemaker/bin/neptune-python-utils-v2/neptune_python_utils.zip /home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.10/site-packages/\n",
+                "unzip -n /home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.10/site-packages/neptune_python_utils.zip -d /home/ec2-user/anaconda3/envs/JupyterSystemEnv/lib/python3.10/site-packages/\n",
                 "sed -i '$d' /home/ec2-user/anaconda3/envs/JupyterSystemEnv/share/jupyter/kernels/python3/kernel.json\n",
                 "sed -i '$d' /home/ec2-user/anaconda3/envs/JupyterSystemEnv/share/jupyter/kernels/python3/kernel.json\n",
                 "echo ' \"language\": \"python\",' >> /home/ec2-user/anaconda3/envs/JupyterSystemEnv/share/jupyter/kernels/python3/kernel.json\n",


### PR DESCRIPTION
CloudFormation templates in amazon-neptune-samples have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (python3.7). The affected templates have been updated to a supported runtime (python3.10).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.